### PR TITLE
Fixes issue #5: change start_date format in config variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ click Variables options you will see few variables already defined. these variab
 ```json
 {
   "tables": ["incident","problem","sc_request"], 
-  "start_date": "1da", 
+  "start_date": "1day", 
   "frequency": "hourly", 
   "threshold": 10000, 
   "export_format": "xml", 
@@ -187,7 +187,7 @@ Options
  you want to ingest data to the storage. Please ensure the values inside the table should be valid ServiceNow table names.
  
  - start_date : ```start_date``` provides you a way to get historical data from your ServiceNow instance. It takes values
- of format ```xda``` , where ```x``` is an integer value which specifies the number of the days in past to fetch data.
+ of format ```xday``` , where ```x``` is an integer value which specifies the number of the days in past to fetch data.
  
  - frequency : ```frequency``` refers the schedule interval of the work flow. It can take value such as ```half-hourly```,
  ```hourly```, ```daily``` etc. 

--- a/docs/user_interface.md
+++ b/docs/user_interface.md
@@ -63,7 +63,7 @@ click Variables options you will see few variables already defined. these variab
 ```json
 {
   "tables": ["incident","problem","sc_request"], 
-  "start_date": "1da", 
+  "start_date": "1day", 
   "frequency": "hourly", 
   "threshold": 10000, 
   "export_format": "xml", 
@@ -78,7 +78,7 @@ Options
  you want to ingest data to the storage. Please ensure the values inside the table should be valid ServiceNow table names.
  
  - start_date : ```start_date``` provides you a way to get historical data from your ServiceNow instance. It takes values
- of format ```xda``` , where ```x``` is an integer value which specifies the number of the days in past to fetch data.
+ of format ```xday``` , where ```x``` is an integer value which specifies the number of the days in past to fetch data.
  
  - frequency : ```frequency``` refers the schedule interval of the work flow. It can take value such as ```half-hourly```,
  ```hourly```, ```daily``` etc. 

--- a/install
+++ b/install
@@ -696,7 +696,7 @@ def create_configuration_variables():
     subprocess.Popen(["{} variables -s config '{}'".format(context.get_airflow_executable(), json.dumps(
         {
             "tables": [],
-            "start_date": "1da",
+            "start_date": "1day",
             "frequency": "hourly",
             "threshold": 10000,
             "export_format": "xml",

--- a/plugins/mbrs/utils/generator.py
+++ b/plugins/mbrs/utils/generator.py
@@ -204,7 +204,7 @@ def create_configuration_variables():
         key='config',
         value=json.dumps({
             "tables": [],
-            "start_date": "1da",
+            "start_date": "1day",
             "frequency": "hourly",
             "threshold": 10000,
             "export_format": "xml",

--- a/tests/utils/test_dates.py
+++ b/tests/utils/test_dates.py
@@ -32,17 +32,26 @@ class TestDates():
     @pytest.mark.start_date
     def test_days_get_start_date(self):
 
-        result1=get_start_date("1da")
+        result1 = get_start_date("1day")
         print(f'{str(get_days(result1))}')
 
-        assert get_days(get_start_date("1da")) == 1
-        assert get_days(get_start_date("2da")) == 2
-        assert get_days(get_start_date("3da")) == 3
-        assert get_days(get_start_date("-3da")) == 3
-        assert get_days(get_start_date("10da")) == 10
+        assert get_days(get_start_date("1day")) == 1
+        assert get_days(get_start_date("1days")) == 1
+        assert get_days(get_start_date("100day")) == 100
+        assert get_days(get_start_date("100days")) == 100
+        assert get_days(get_start_date("2days")) == 2
+        assert get_days(get_start_date("3days")) == 3
+        assert get_days(get_start_date("-3days")) == 3
+        assert get_days(get_start_date("10days")) == 10
 
         with pytest.raises(BadStartDatePreset):
             get_start_date("2xx")
+
+        with pytest.raises(BadStartDatePreset):
+            get_start_date("10months")
+
+        with pytest.raises(BadStartDatePreset):
+            get_start_date("10")
 
     @pytest.mark.days_ago
     def test_days_ago(self):


### PR DESCRIPTION
change start_date format in `config` variable from `xda` to `xday` and `xdays`
- updates README.md for the change
- updates test_dates
- updates install script
- updates generator and date utils